### PR TITLE
Upgrade to last go-blindsecp256k1 version

### DIFF
--- a/csp/csp_test.go
+++ b/csp/csp_test.go
@@ -31,7 +31,8 @@ func TestBlindCA(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	// Generate a new R point for blinding
-	signerR := ca.NewBlindRequestKey()
+	signerR, err := ca.NewBlindRequestKey()
+	qt.Assert(t, err, qt.IsNil)
 
 	// Prepare the hash that will be signed
 	hash := ethereum.HashRaw(randomBytes(128))

--- a/csp/handler.go
+++ b/csp/handler.go
@@ -74,7 +74,7 @@ func (csp *BlindCSP) signatureReq(msg *bearerstdapi.BearerStandardAPIdata,
 			if err != nil {
 				return err
 			}
-			resp.Token = r.Bytes()
+			resp.Token = r.BytesUncompressed() // use Uncompressed for blindsecp256k1-js compatibility
 		case SignatureTypeEthereum:
 			resp.Token = csp.NewRequestKey()
 		default:
@@ -113,7 +113,8 @@ func (csp *BlindCSP) signature(msg *bearerstdapi.BearerStandardAPIdata,
 	resp := Message{}
 	switch ctx.URLParam("signType") {
 	case SignatureTypeBlind:
-		r, err := blindsecp256k1.NewPointFromBytes(req.Token)
+		// use Uncompressed for blindsecp256k1-js compatibility
+		r, err := blindsecp256k1.NewPointFromBytesUncompressed(req.Token)
 		if err != nil {
 			return err
 		}

--- a/csp/handler.go
+++ b/csp/handler.go
@@ -70,7 +70,11 @@ func (csp *BlindCSP) signatureReq(msg *bearerstdapi.BearerStandardAPIdata,
 	if ok, resp.Response = csp.AuthCallback(ctx.Request, req, pid, signType); ok {
 		switch signType {
 		case SignatureTypeBlind:
-			resp.Token = csp.NewBlindRequestKey().Bytes()
+			r, err := csp.NewBlindRequestKey()
+			if err != nil {
+				return err
+			}
+			resp.Token = r.Bytes()
 		case SignatureTypeEthereum:
 			resp.Token = csp.NewRequestKey()
 		default:

--- a/csp/helpers.go
+++ b/csp/helpers.go
@@ -48,17 +48,21 @@ func (csp *BlindCSP) PubKeyECDSA(processID []byte) string {
 
 // NewBlindRequestKey generates a new request key for blinding a content on the client side.
 // It returns SignerR and SignerQ values.
-func (csp *BlindCSP) NewBlindRequestKey() *blind.Point {
-	k, signerR := blind.NewRequestParameters()
+func (csp *BlindCSP) NewBlindRequestKey() (*blind.Point, error) {
+	k, signerR, err := blind.NewRequestParameters()
+	if err != nil {
+		log.Warn(err)
+		return nil, err
+	}
 	index := signerR.X.String() + signerR.Y.String()
 	if err := csp.addKey(index, k); err != nil {
 		log.Warn(err)
-		return nil
+		return nil, err
 	}
 	if k.Uint64() == 0 {
-		return nil
+		return nil, fmt.Errorf("k can not be 0, k: %s", k)
 	}
-	return signerR
+	return signerR, nil
 }
 
 // NewRequestKey generates a new request key for blinding a content on the client side.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vocdoni/blind-csp
 go 1.15
 
 require (
-	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d
+	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f
 	github.com/ethereum/go-ethereum v1.10.13
 	github.com/frankban/quicktest v1.14.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210203222605-876755a714c3/go.mod h1:10oM1DQMpukFfSzNsjSQG2rE6UjoGsXT4iIxWIiVbu0=
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d h1:QRip5Otx+8mDr77Z3AtTi3aq5cksZHyvDarzOo/vj7g=
 github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d/go.mod h1:10oM1DQMpukFfSzNsjSQG2rE6UjoGsXT4iIxWIiVbu0=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211118154512-04b9532b53ac h1:klcLRFYJB+o90gTUkoNYOAH+EOo60iazn1M0QwXSqsQ=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211118154512-04b9532b53ac/go.mod h1:n598ze+TUwDUQ2mbbiKgitcH6UNJlVYX6sLc08iI1nM=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f h1:+9bA9YJEr8gb+F4rsJ2EYIyaB/3+nKcuOiUStTAf1Pg=
+github.com/arnaucube/go-blindsecp256k1 v0.0.0-20211204171003-644e7408753f/go.mod h1:n598ze+TUwDUQ2mbbiKgitcH6UNJlVYX6sLc08iI1nM=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/saltedkey/saltedkey_test.go
+++ b/saltedkey/saltedkey_test.go
@@ -47,7 +47,8 @@ func TestBlindsaltedKey(t *testing.T) {
 	msgHash := ethereum.HashRaw([]byte("hello world!"))
 
 	// Server: generate a new secretK and R (R is required for blinding and K for signing)
-	k, signerR := blind.NewRequestParameters()
+	k, signerR, err := blind.NewRequestParameters()
+	qt.Assert(t, err, qt.IsNil)
 
 	// Client: blinds the message with R (from server). Keeps userSecretData for unblinding
 	msgBlinded, userSecretData, err := blindsecp256k1.Blind(new(big.Int).SetBytes(msgHash), signerR)


### PR DESCRIPTION
- Upgrade to last go-blindsecp256k1 version
- Update NewBlindRequestKey method to return error to upper levels
instead of just printing the error

One comment, the current `go-blindsecp256k1` version parsers use compressed format of points (& signatures & public keys), so for example a compressed point instead of 64 bytes needs 33 bytes. This is not compatible with the parsers in the [blindsecp256k1-js](https://github.com/arnaucube/blindsecp256k1-js) implementation, which currently does not have support yet for compressed format.
The [go-blindsecp256k1](https://github.com/arnaucube/go-blindsecp256k1) apart from the 'compressed' parsers, it still has the 'uncompressed' parsers (in the [uncompressed.go](https://github.com/arnaucube/go-blindsecp256k1/blob/master/uncompressed.go) file), which are the ones being used in the `blind-csp` server in this PR for when sending & receiving data that comes from the js implementation. If in the future the js version supports compressed format parsers, we can update `blind-csp` and `vocdoni-node` with the compressed methods.

This PR goes paired with https://github.com/vocdoni/vocdoni-node/pull/412 .