### PR TITLE
Add a health check handler

### DIFF
--- a/csp/handler.go
+++ b/csp/handler.go
@@ -39,11 +39,20 @@ func (csp *BlindCSP) registerHandlers() error {
 		return err
 	}
 
-	return csp.api.RegisterMethod(
+	if err := csp.api.RegisterMethod(
 		"/processes/{processId}/sharedkey",
 		"POST",
 		bearerstdapi.MethodAccessTypePublic,
 		csp.sharedKeyReq,
+	); err != nil {
+		return err
+	}
+
+	return csp.api.RegisterMethod(
+		"/health",
+		"GET",
+		bearerstdapi.MethodAccessTypePublic,
+		csp.health,
 	)
 }
 
@@ -157,6 +166,15 @@ func (csp *BlindCSP) sharedKeyReq(msg *bearerstdapi.BearerStandardAPIdata,
 	} else {
 		return fmt.Errorf("unauthorized")
 	}
+	return ctx.Send(resp.Marshal())
+}
+
+// https://server/v1/auth/health
+
+// health is a simple health check handler.
+func (csp *BlindCSP) health(msg *bearerstdapi.BearerStandardAPIdata,
+	ctx *httprouter.HTTPContext) error {
+	resp := &Message{Response: "Ok."}
 	return ctx.Send(resp.Marshal())
 }
 


### PR DESCRIPTION
In order to have future k8s deployments, it is highly recommended to have a health check endpoint to probe the availability of the API. Just a simple message with a 200 response to a GET works.


Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request