### PR TITLE
smshandler: use a map instead of array for storing elections

### DIFF
--- a/handlers/smshandler/queue.go
+++ b/handlers/smshandler/queue.go
@@ -84,7 +84,7 @@ func (sq *smsQueue) run() {
 			log.Infof("re-enqueued sms for %d, attempt #%d", *challenge.phone.NationalNumber, challenge.tries)
 			continue
 		}
-		log.Debug("sms with challenge for %d successfully sent, sending channel signal", *challenge.phone.NationalNumber)
+		log.Debugf("sms with challenge for %d successfully sent, sending channel signal", *challenge.phone.NationalNumber)
 		// Send a signal (channel) to let the caller know we succeed
 		sq.response <- smsQueueResponse{
 			userID:     challenge.userID,

--- a/handlers/smshandler/storage.go
+++ b/handlers/smshandler/storage.go
@@ -1,7 +1,6 @@
 package smshandler
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -35,7 +34,7 @@ type Users struct {
 // UserData represents a user of the SMS handler.
 type UserData struct {
 	UserID    types.HexBytes            `json:"userID,omitempty" bson:"_id"`
-	Elections []UserElection            `json:"elections,omitempty" bson:"elections,omitempty"`
+	Elections map[string]UserElection   `json:"elections,omitempty" bson:"elections,omitempty"`
 	ExtraData string                    `json:"extraData,omitempty" bson:"extradata,omitempty"`
 	Phone     *phonenumbers.PhoneNumber `json:"phone,omitempty" bson:"phone,omitempty"`
 }
@@ -68,17 +67,6 @@ func HexBytesToElection(electionIDs []types.HexBytes, attempts int) []UserElecti
 		elections = append(elections, ue)
 	}
 	return elections
-}
-
-// FindElection returns the election index.
-// -1 is returned if the election ID is not found.
-func (ud *UserData) FindElection(electionID types.HexBytes) int {
-	for i, e := range ud.Elections {
-		if bytes.Equal(electionID, e.ElectionID) {
-			return i
-		}
-	}
-	return -1
 }
 
 // Storage interface implements the storage layer for the smshandler


### PR DESCRIPTION
It takes more memory but its faster and avoids potential races
since an electionID can only exist once for a user now.

Signed-off-by: p4u <pau@dabax.net>