### PR TITLE
storage: add Reset method to interface

### DIFF
--- a/handlers/smshandler/jsonstorage.go
+++ b/handlers/smshandler/jsonstorage.go
@@ -41,6 +41,11 @@ func (js *JSONstorage) Init(dataDir string, maxAttempts int, coolDownTime time.D
 	return nil
 }
 
+// Reset does nothing on this storage
+func (js *JSONstorage) Reset() error {
+	return nil
+}
+
 func (js *JSONstorage) Users() (*Users, error) {
 	var us Users
 	if err := js.kv.Iterate(nil, func(key, value []byte) bool {

--- a/handlers/smshandler/storage.go
+++ b/handlers/smshandler/storage.go
@@ -79,6 +79,8 @@ type Storage interface {
 	// Init initializes the storage, maxAttempts is used to set the default maximum SMS attempts.
 	// CoolDownTime is the time period on which attempts are allowed.
 	Init(dataDir string, maxAttempts int, coolDownTime time.Duration) (err error)
+	// Reset clears the storage content
+	Reset() (err error)
 	// AddUser adds a new user to the storage
 	AddUser(userID types.HexBytes, processIDs []types.HexBytes, phone, extra string) (err error)
 	// Users returns the list of users


### PR DESCRIPTION
the Init method of mongodbstorage was buggy, it didn't properly recreate
indexes after a db reset.

refactor the whole process into a new method Reset and a helper createIndexes
